### PR TITLE
Match upstream dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 698cd7bc3c7d1b82bb728bae835724a486a8c376647aec336aa21a60113c3645
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py2k]
 
@@ -23,13 +23,13 @@ requirements:
     - cython
   run:
     - python
-    - async-timeout <4.0,>=3.0
+    - async-timeout >=4.0a2,<5.0
     - attrs >=17.3.0
     - chardet >=2.0,<4.0
     - idna_ssl >=1.0  # [py<37]
-    - multidict >=4.5,<5.0
+    - multidict >=4.5,<7.0
     - typing-extensions >=3.6.5  # [py<37]
-    - yarl >=1.0,<1.6.0
+    - yarl >=1.0,<2.0
 
 test:
   imports:


### PR DESCRIPTION
This PR matches dependencies in `run` with those specified in the "upstream" `setup.py`.